### PR TITLE
Add .gitignore for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# Environment variables (secrets!)
+.env
+.env.local
+
+# IDE settings
+.vscode/
+.idea/
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- Dodaje `.gitignore` dla projektu Python
- Ignoruje: `__pycache__`, `venv`, `.env`, pliki IDE, itp.

## Co to zmienia?
Git będzie ignorował niepotrzebne pliki i nie pozwoli przypadkowo wrzucić haseł/kluczy API na GitHub.